### PR TITLE
用TypeScript2.8引入的新类型ReturnType获取函数返回值

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const actions = {
 console.log(actions.changeId(3));  // { type: 'test/chagneId', payload: 3 };
 ```
 
-if the action creator arguments and payload is not equal, you car define a custom arguments => payload transfer function. Both the argument and the return action object are type-safe, the return action object type will be inferred.
+if the action creator arguments and payload is not equal, you can define a custom arguments => payload transfer function. Both the argument and the return action object are type-safe, the return action object type will be inferred.
 
 ```js
 const actions = {

--- a/index.ts
+++ b/index.ts
@@ -110,9 +110,9 @@ export function createFetchAction<Key>(types: IFetchTypes<Key>, url: string, met
 }
 
 /** 根据 Reducer Map 返回 全局 State */
-export type ReturnState<ReducerMap> = {
-  [key in keyof ReducerMap]: ReducerMap[key] extends (state: any, action: any) => infer R ? R : any
-};
+export type ReturnState<
+  ReducerMap extends { [key: string]: (state: any, action: any) => any }
+> = { [key in keyof ReducerMap]: ReturnType<ReducerMap[key]> };
 
 type ValueOf<T> = T[keyof T];
 
@@ -120,8 +120,10 @@ type ValueOf<T> = T[keyof T];
  *
  * 获取 action 类型
  */
-export type ActionType<Actions> =
-  | ValueOf<{ [key in keyof Actions]: Actions[key] extends (...args: any[]) => infer R ? R : never }>
+export type ActionType<
+  Actions extends { [key: string]: (...args: any[]) => any }
+> =
+  | ValueOf<{ [key in keyof Actions]: ReturnType<Actions[key]> }>
   | {
       type: 'error';
       payload?: { message: string; [key: string]: any };


### PR DESCRIPTION
看到目前代码里ReturnState 和 ActionType 都用Conditional Types 获取函数的返回值，其实TypeScript 2.8 已经内置了一个利用Conditional Types获取函数返回值的类型 ReturnType，可以用在ReturnState和ActionType的定义里简化代码。 🙂