### PR TITLE
fix: fix bad never type inference under `--strictFunctionTypes`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -129,6 +129,7 @@ type ValueOf<T> = T[keyof T];
  */
 export type ActionType<Actions> =
   | ValueOf<{ [key in keyof Actions]: Actions[key] extends (...args: any[]) => infer R ? R : never }>
+  | ValueOf<{ [key in keyof Actions]: Actions[key] extends (arg: never, ...args: any[]) => infer R ? R : never }>
   | {
       type: 'error';
       payload?: { message: string; [key: string]: any };


### PR DESCRIPTION
修复开启strictFunctionTypes后，函数类型参数的检查是抗变时，never类型推断报错问题。